### PR TITLE
Fix infinite loop in trailingRpImageMetadata on brace-at-index-0 JSON

### DIFF
--- a/src/chat/rpOutput.ts
+++ b/src/chat/rpOutput.ts
@@ -54,7 +54,12 @@ function trailingRpImageMetadata(value: string) {
   if (!text.endsWith('}')) {
     return undefined;
   }
-  for (let start = text.lastIndexOf('{'); start >= 0; start = text.lastIndexOf('{', start - 1)) {
+  // NOTE: `String.lastIndexOf('{', -1)` clamps the negative fromIndex to 0 and so
+  // returns 0 again when the text starts with '{'. Advancing via `start - 1`
+  // therefore spins forever on inputs like `{"image":""}` (a JSON object at
+  // index 0 whose metadata is empty/invalid, e.g. an empty/refused image prompt).
+  // Stop once we reach the opening brace at index 0 instead of re-searching from -1.
+  for (let start = text.lastIndexOf('{'); start >= 0; start = start <= 0 ? -1 : text.lastIndexOf('{', start - 1)) {
     try {
       const metadata = JSON.parse(text.slice(start)) as unknown;
       const parsedMetadata = rpOutputMetadata(metadata);


### PR DESCRIPTION
trailingRpImageMetadata scans backwards for the opening brace of a trailing JSON metadata object:

  for (let start = text.lastIndexOf('{'); start >= 0; start = text.lastIndexOf('{', start - 1))

When `start` reaches 0, the loop update evaluates `lastIndexOf('{', -1)`. JavaScript clamps a negative fromIndex to 0, so it returns 0 again for any text that begins with '{'. `start` is then stuck at 0 and the loop spins forever, hard-locking the main thread.

This triggers on any model output that is itself a JSON object (opening brace at index 0, closing brace at the end) whose metadata is empty or invalid — e.g. `{"image":""}`, which an image-prompt node emits when the model returns an empty or refused prompt.

Fix: stop once the brace at index 0 has been tried, instead of re-searching from -1:

  start = start <= 0 ? -1 : text.lastIndexOf('{', start - 1)