### PR TITLE
Isolate the live run-duration clock into a self-contained leaf component

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -124,6 +124,7 @@ import {
 } from './data-management/sessionStore';
 import { isRpgraphSessionV2 } from './data-management/validation';
 import type { RpgraphSessionV2 } from './data-management/types';
+import { LiveRunClock } from './components/LiveRunClock';
 import {
   appointmentsFromEventEntities,
   eventEntitiesFromNodes,
@@ -295,9 +296,6 @@ type DeletedGraphRestoreAction = {
   edges: Edge[];
 };
 
-function formatRuntimeSeconds(durationMs: number) {
-  return (durationMs / 1000).toFixed(2);
-}
 
 
 
@@ -5611,7 +5609,7 @@ function App() {
                 disabled={!runLlmReport}
                 title="Show LLM calls for the current or last run"
               >
-                Runtime: {formatRuntimeSeconds(runDurationMs)} s
+                Runtime: <LiveRunClock isRunning={isRunning} finalMs={runDurationMs} /> s
               </button>
               <WorkflowCapabilityStrip indicators={workflowCapabilityIndicators} />
               {visibleLogEntry && (

--- a/src/app/useRunLifecycle.ts
+++ b/src/app/useRunLifecycle.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import type {
   LlmRunHistoryEntry,
   RunLlmReport,
@@ -26,19 +26,12 @@ export function useRunLifecycle() {
   const runStartTimeRef = useRef<number | null>(null);
   const runEndTimeRef = useRef<number | null>(null);
 
-  useEffect(() => {
-    if (!isRunning) {
-      return;
-    }
-    const intervalId = setInterval(() => {
-      if (runStartTimeRef.current !== null) {
-        setRunDurationMs(performance.now() - runStartTimeRef.current);
-      }
-    }, 50);
-    return () => {
-      clearInterval(intervalId);
-    };
-  }, [isRunning]);
+  // NOTE: the live run-duration display is driven by the self-contained
+  // <LiveRunClock> leaf component, NOT by an App-level interval. A former 50ms
+  // setRunDurationMs interval here re-rendered the ENTIRE app (incl. the whole
+  // conversation) 20x/second; on a large session each render takes ~750ms, so
+  // they ran back-to-back and pegged the main thread for the whole run, freezing
+  // the tab. The final duration is set once in runGraph's finishRun().
 
   function updateWorkflowComfyGenerationActive(active: boolean) {
     workflowComfyGenerationActiveCountRef.current = Math.max(

--- a/src/components/AppDialogs.tsx
+++ b/src/components/AppDialogs.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState, type FormEvent, type PointerEvent as ReactPointerEvent } from 'react';
 import { DarkAudioPlayer } from './DarkAudioPlayer';
+import { LiveRunClock } from './LiveRunClock';
 import { outputFormatHelp, type OutputFormatHelpKind } from '../nodes/output/formatHelp';
 import { CustomNodeBody } from '../nodes/custom-node/Card';
 import {
@@ -200,7 +201,9 @@ export function RunLlmReportDialog({
           <div className="run-llm-card-row">
             <span className="run-llm-card-label">Duration</span>
             <span className="run-llm-card-value font-mono">
-              {durationMs !== undefined ? `${formatRuntimeSeconds(durationMs)} s` : '-'}
+              {isCurrent && isRunning
+                ? <><LiveRunClock isRunning={isRunning} finalMs={durationMs ?? 0} /> s</>
+                : durationMs !== undefined ? `${formatRuntimeSeconds(durationMs)} s` : '-'}
             </span>
           </div>
           <div className="run-llm-card-row">

--- a/src/components/LiveRunClock.tsx
+++ b/src/components/LiveRunClock.tsx
@@ -1,0 +1,40 @@
+import { useEffect, useRef, useState } from 'react';
+
+function formatRuntimeSeconds(durationMs: number) {
+  return (durationMs / 1000).toFixed(2);
+}
+
+/**
+ * Self-contained live run timer.
+ *
+ * While `isRunning`, this ticks its OWN local state, so only this small leaf
+ * re-renders — never the whole app. It replaces a former App-level 50ms
+ * `setRunDurationMs` interval (useRunLifecycle) that updated App state 20x per
+ * second and thereby re-rendered the entire conversation on every tick. On a
+ * large session a single such render takes ~750ms, so those renders ran
+ * back-to-back and pegged the main thread for the whole run — freezing the UI,
+ * worst during long no-stream waits (e.g. a custom node's internal LLM call).
+ *
+ * When not running, it shows the final duration passed in `finalMs`.
+ */
+export function LiveRunClock({ isRunning, finalMs }: { isRunning: boolean; finalMs: number }) {
+  const [elapsedMs, setElapsedMs] = useState(0);
+  const startRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!isRunning) {
+      startRef.current = null;
+      return;
+    }
+    startRef.current = performance.now();
+    setElapsedMs(0);
+    const id = window.setInterval(() => {
+      if (startRef.current !== null) {
+        setElapsedMs(performance.now() - startRef.current);
+      }
+    }, 200);
+    return () => window.clearInterval(id);
+  }, [isRunning]);
+
+  return <>{formatRuntimeSeconds(isRunning ? elapsedMs : finalMs)}</>;
+}


### PR DESCRIPTION
The live "Runtime: X.XX s" display was driven by a 50ms setInterval in useRunLifecycle that called setRunDurationMs (App-level state) 20 times per second for the whole run. Each update re-rendered the ENTIRE app, including the full conversation. On a large session a single render can take ~750ms, so the renders ran back-to-back and pegged the main thread for the entire run — freezing the UI. It is worst during a no-stream wait (e.g. a custom node's own internal LLM call), where the timer is the only thing forcing re-renders.

Fix: remove the App-level ticker and drive the live display from a new self-contained <LiveRunClock> leaf that ticks its OWN local state (200ms), so only that tiny node re-renders — never the app or the conversation. The final duration is still set once when the run finishes, so behaviour is unchanged.