### PR TITLE
Isolate the live run-duration clock into a self-contained leaf component

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -995,6 +995,8 @@ function App() {
     pendingRunRestartRef,
     runStartTimeRef,
     runEndTimeRef,
+    runStartTimeMs,
+    setRunStartTimeMs,
     cancelCurrentRun,
   } = useRunLifecycle();
   const [characterDropdownOpen, setCharacterDropdownOpen] = useState(false);
@@ -4525,6 +4527,7 @@ function App() {
     setActiveRunId,
     setIsRunning,
     setRunDurationMs,
+    setRunStartTimeMs,
     runStartTimeRef,
     runEndTimeRef,
     pendingRunRestart: pendingRunRestartRef,
@@ -5452,6 +5455,7 @@ function App() {
           currentDurationMs={runDurationMs}
           history={runHistory}
           isRunning={isRunning && activeRunId === runLlmReport.runId}
+          runStartTimeMs={runStartTimeMs}
           onClose={() => setShowRunLlmReport(false)}
         />
       )}
@@ -5609,7 +5613,7 @@ function App() {
                 disabled={!runLlmReport}
                 title="Show LLM calls for the current or last run"
               >
-                Runtime: <LiveRunClock isRunning={isRunning} finalMs={runDurationMs} /> s
+                Runtime: <LiveRunClock isRunning={isRunning} startTimeMs={runStartTimeMs} finalMs={runDurationMs} /> s
               </button>
               <WorkflowCapabilityStrip indicators={workflowCapabilityIndicators} />
               {visibleLogEntry && (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -124,6 +124,7 @@ import {
 } from './data-management/sessionStore';
 import { isRpgraphSessionV2 } from './data-management/validation';
 import type { RpgraphSessionV2 } from './data-management/types';
+import { LiveRunClock } from './components/LiveRunClock';
 import {
   appointmentsFromEventEntities,
   eventEntitiesFromNodes,
@@ -295,9 +296,6 @@ type DeletedGraphRestoreAction = {
   edges: Edge[];
 };
 
-function formatRuntimeSeconds(durationMs: number) {
-  return (durationMs / 1000).toFixed(2);
-}
 
 
 
@@ -5611,7 +5609,7 @@ function App() {
                 disabled={!runLlmReport}
                 title="Show LLM calls for the current or last run"
               >
-                Runtime: {formatRuntimeSeconds(runDurationMs)} s
+                Runtime: <LiveRunClock isRunning={isRunning} finalMs={runDurationMs} /> s
               </button>
               <WorkflowCapabilityStrip indicators={workflowCapabilityIndicators} />
               {visibleLogEntry && (

--- a/src/app/useGraphRun.ts
+++ b/src/app/useGraphRun.ts
@@ -227,6 +227,7 @@ type UseGraphRunOptions = Pick<
   setActiveRunId: (runId: string | null) => void;
   setIsRunning: (running: boolean) => void;
   setRunDurationMs: (ms: number) => void;
+  setRunStartTimeMs: (ms: number | null) => void;
   runStartTimeRef: Ref<number | null>;
   runEndTimeRef: Ref<number | null>;
   pendingRunRestart: Ref<(() => void) | null>;
@@ -356,6 +357,7 @@ export function useGraphRun(options: UseGraphRunOptions) {
     setActiveRunId,
     setIsRunning,
     setRunDurationMs,
+    setRunStartTimeMs,
     runStartTimeRef,
     runEndTimeRef,
     pendingRunRestart,
@@ -615,6 +617,7 @@ export function useGraphRun(options: UseGraphRunOptions) {
     setNodes(resetRunNodes);
     removeReplacedMessages();
     runStartTimeRef.current = runClockNow();
+    setRunStartTimeMs(runStartTimeRef.current);
     runEndTimeRef.current = null;
     setRunDurationMs(0);
     setIsRunning(true);

--- a/src/app/useRunLifecycle.ts
+++ b/src/app/useRunLifecycle.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import type {
   LlmRunHistoryEntry,
   RunLlmReport,
@@ -26,19 +26,12 @@ export function useRunLifecycle() {
   const runStartTimeRef = useRef<number | null>(null);
   const runEndTimeRef = useRef<number | null>(null);
 
-  useEffect(() => {
-    if (!isRunning) {
-      return;
-    }
-    const intervalId = setInterval(() => {
-      if (runStartTimeRef.current !== null) {
-        setRunDurationMs(performance.now() - runStartTimeRef.current);
-      }
-    }, 50);
-    return () => {
-      clearInterval(intervalId);
-    };
-  }, [isRunning]);
+  // NOTE: the live run-duration display is driven by the self-contained
+  // <LiveRunClock> leaf component, NOT by an App-level interval. A former 50ms
+  // setRunDurationMs interval here re-rendered the ENTIRE app (incl. the whole
+  // conversation) 20x/second; on a large session each render takes ~750ms, so
+  // they ran back-to-back and pegged the main thread for the whole run, freezing
+  // the tab. The final duration is set once in runGraph's finishRun().
 
   function updateWorkflowComfyGenerationActive(active: boolean) {
     workflowComfyGenerationActiveCountRef.current = Math.max(

--- a/src/app/useRunLifecycle.ts
+++ b/src/app/useRunLifecycle.ts
@@ -25,6 +25,9 @@ export function useRunLifecycle() {
   const pendingRunRestart = useRef<(() => void) | null>(null);
   const runStartTimeRef = useRef<number | null>(null);
   const runEndTimeRef = useRef<number | null>(null);
+  // Render-safe mirror of runStartTimeRef for the <LiveRunClock> instances
+  // (React forbids reading refs during render).
+  const [runStartTimeMs, setRunStartTimeMs] = useState<number | null>(null);
 
   // NOTE: the live run-duration display is driven by the self-contained
   // <LiveRunClock> leaf component, NOT by an App-level interval. A former 50ms
@@ -76,6 +79,8 @@ export function useRunLifecycle() {
     pendingRunRestartRef: pendingRunRestart,
     runStartTimeRef,
     runEndTimeRef,
+    runStartTimeMs,
+    setRunStartTimeMs,
     cancelCurrentRun,
   };
 }

--- a/src/components/AppDialogs.tsx
+++ b/src/components/AppDialogs.tsx
@@ -177,12 +177,14 @@ export function RunLlmReportDialog({
   currentDurationMs,
   history,
   isRunning,
+  runStartTimeMs,
   onClose,
 }: {
   currentReport: RunLlmReport;
   currentDurationMs: number;
   history: LlmRunHistoryEntry[];
   isRunning: boolean;
+  runStartTimeMs: number | null;
   onClose: () => void;
 }) {
   const backdropDismiss = useBackdropDismiss<HTMLDivElement>(onClose);
@@ -202,7 +204,7 @@ export function RunLlmReportDialog({
             <span className="run-llm-card-label">Duration</span>
             <span className="run-llm-card-value font-mono">
               {isCurrent && isRunning
-                ? <><LiveRunClock isRunning={isRunning} finalMs={durationMs ?? 0} /> s</>
+                ? <><LiveRunClock isRunning={isRunning} startTimeMs={runStartTimeMs} finalMs={durationMs ?? 0} /> s</>
                 : durationMs !== undefined ? `${formatRuntimeSeconds(durationMs)} s` : '-'}
             </span>
           </div>

--- a/src/components/AppDialogs.tsx
+++ b/src/components/AppDialogs.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState, type FormEvent, type PointerEvent as ReactPointerEvent } from 'react';
 import { DarkAudioPlayer } from './DarkAudioPlayer';
+import { LiveRunClock } from './LiveRunClock';
 import { outputFormatHelp, type OutputFormatHelpKind } from '../nodes/output/formatHelp';
 import { CustomNodeBody } from '../nodes/custom-node/Card';
 import {
@@ -200,7 +201,9 @@ export function RunLlmReportDialog({
           <div className="run-llm-card-row">
             <span className="run-llm-card-label">Duration</span>
             <span className="run-llm-card-value font-mono">
-              {durationMs !== undefined ? `${formatRuntimeSeconds(durationMs)} s` : '-'}
+              {isCurrent && isRunning
+                ? <><LiveRunClock isRunning={isRunning} finalMs={durationMs ?? 0} /> s</>
+                : durationMs !== undefined ? `${formatRuntimeSeconds(durationMs)} s` : '-'}
             </span>
           </div>
           <div className="run-llm-card-row">

--- a/src/components/LiveRunClock.tsx
+++ b/src/components/LiveRunClock.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 function formatRuntimeSeconds(durationMs: number) {
   return (durationMs / 1000).toFixed(2);
@@ -7,7 +7,7 @@ function formatRuntimeSeconds(durationMs: number) {
 /**
  * Self-contained live run timer.
  *
- * While `isRunning`, this ticks its OWN local state, so only this small leaf
+ * While `isRunning`, an interval ticks LOCAL state, so only this small leaf
  * re-renders — never the whole app. It replaces a former App-level 50ms
  * `setRunDurationMs` interval (useRunLifecycle) that updated App state 20x per
  * second and thereby re-rendered the entire conversation on every tick. On a
@@ -15,26 +15,37 @@ function formatRuntimeSeconds(durationMs: number) {
  * back-to-back and pegged the main thread for the whole run — freezing the UI,
  * worst during long no-stream waits (e.g. a custom node's internal LLM call).
  *
- * When not running, it shows the final duration passed in `finalMs`.
+ * The elapsed time is always derived from `startTimeMs` (the run's real start
+ * on the `performance.now()` clock), never from this component's mount time.
+ * That keeps every instance in sync and correct even when one mounts mid-run,
+ * e.g. inside the run report dialog. When not running, it shows the final
+ * duration passed in `finalMs`.
  */
-export function LiveRunClock({ isRunning, finalMs }: { isRunning: boolean; finalMs: number }) {
+export function LiveRunClock({
+  isRunning,
+  startTimeMs,
+  finalMs,
+}: {
+  isRunning: boolean;
+  startTimeMs: number | null;
+  finalMs: number;
+}) {
   const [elapsedMs, setElapsedMs] = useState(0);
-  const startRef = useRef<number | null>(null);
 
   useEffect(() => {
-    if (!isRunning) {
-      startRef.current = null;
+    if (!isRunning || startTimeMs === null) {
       return;
     }
-    startRef.current = performance.now();
-    setElapsedMs(0);
-    const id = window.setInterval(() => {
-      if (startRef.current !== null) {
-        setElapsedMs(performance.now() - startRef.current);
-      }
-    }, 200);
-    return () => window.clearInterval(id);
-  }, [isRunning]);
+    const update = () => setElapsedMs(performance.now() - startTimeMs);
+    // Immediate async tick so an instance mounted mid-run (e.g. the report
+    // dialog) shows the true elapsed time right away, not after 200ms.
+    const timeoutId = window.setTimeout(update, 0);
+    const intervalId = window.setInterval(update, 200);
+    return () => {
+      window.clearTimeout(timeoutId);
+      window.clearInterval(intervalId);
+    };
+  }, [isRunning, startTimeMs]);
 
   return <>{formatRuntimeSeconds(isRunning ? elapsedMs : finalMs)}</>;
 }

--- a/src/components/LiveRunClock.tsx
+++ b/src/components/LiveRunClock.tsx
@@ -1,0 +1,40 @@
+import { useEffect, useRef, useState } from 'react';
+
+function formatRuntimeSeconds(durationMs: number) {
+  return (durationMs / 1000).toFixed(2);
+}
+
+/**
+ * Self-contained live run timer.
+ *
+ * While `isRunning`, this ticks its OWN local state, so only this small leaf
+ * re-renders — never the whole app. It replaces a former App-level 50ms
+ * `setRunDurationMs` interval (useRunLifecycle) that updated App state 20x per
+ * second and thereby re-rendered the entire conversation on every tick. On a
+ * large session a single such render takes ~750ms, so those renders ran
+ * back-to-back and pegged the main thread for the whole run — freezing the UI,
+ * worst during long no-stream waits (e.g. a custom node's internal LLM call).
+ *
+ * When not running, it shows the final duration passed in `finalMs`.
+ */
+export function LiveRunClock({ isRunning, finalMs }: { isRunning: boolean; finalMs: number }) {
+  const [elapsedMs, setElapsedMs] = useState(0);
+  const startRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!isRunning) {
+      startRef.current = null;
+      return;
+    }
+    startRef.current = performance.now();
+    setElapsedMs(0);
+    const id = window.setInterval(() => {
+      if (startRef.current !== null) {
+        setElapsedMs(performance.now() - startRef.current);
+      }
+    }, 200);
+    return () => window.clearInterval(id);
+  }, [isRunning]);
+
+  return <>{formatRuntimeSeconds(isRunning ? elapsedMs : finalMs)}</>;
+}


### PR DESCRIPTION
Supersedes #6 (same branch, plus review fixes). The original commit by @rostchri is included unchanged; on top of it, review issues found in #6 are fixed:

- **ESLint failures**: the first version violated `react-hooks/set-state-in-effect`; an intermediate attempt hit `react-hooks/purity` and `react-hooks/refs`. The final version is lint-clean.
- **Clock reset on dialog open**: a `LiveRunClock` mounted mid-run (run report dialog) started counting from zero because each instance derived its start from its own mount time.
- **Diverging times**: header clock and report dialog clock could disagree for the same run.

Fix: the run start timestamp is kept as render-safe React state (`runStartTimeMs` in `useRunLifecycle`, set in `runGraph` next to `runStartTimeRef`) and passed into every `LiveRunClock`, so all instances derive the same, correct elapsed time from the run's real start. The performance goal of #6 is preserved: only the tiny leaf component re-renders while a run is active, never the whole app.

Verified: `npm run lint`, `npm run build`, `npm run check:unused` all pass.

Review fixes were applied by Claude (Fable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)