### PR TITLE
fix: skip translation LLM call when input text is empty

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3558,6 +3558,12 @@ function App() {
     recentHistoryContext = '',
     label = 'Translate',
   ) {
+    // Nothing to translate — skip the LLM call. Passing an empty string to the
+    // translator otherwise yields a spurious "I don't see the text to translate"
+    // style reply that surfaces as the translated output.
+    if (!text.trim()) {
+      return '';
+    }
     const language = displayLanguageOverride.trim() || 'German';
     const prompt = translationPrompt({
       text,


### PR DESCRIPTION
translateText built a translation prompt and called the LLM even when the input `text` was empty. Given no source text, the model can return a spurious reply (e.g. "I don't see the text you'd like me to translate") instead of an empty string, and that reply then surfaces as the translated output.

This happens whenever a turn legitimately produces no text to translate — for example when an output text selector routes to an empty branch on a given turn.

Guard: return an empty string immediately for empty/whitespace input, so the translator is never invoked with nothing to translate. Applies uniformly to input, output, and phone translation.