### PR TITLE
fix: robust parsing for action JSON preamble + empty TOON arrays

### DIFF
--- a/src/nodes/shared/promptActions.ts
+++ b/src/nodes/shared/promptActions.ts
@@ -1193,7 +1193,32 @@ export function parsePromptActionCall(text: string): ParsedPromptActionCall | un
   } catch {
     // Fall through to the multi-object parser below.
   }
-  return parsePromptActionFromJsonSequence(parseText);
+  return parsePromptActionFromJsonSequence(parseText) ?? parseEmbeddedPromptActionCall(parseText);
+}
+
+// Reasoning-capable models (e.g. Claude Opus) may prepend a sentence of narration
+// before the action JSON ("Let me first check if there's a stored image ...").
+// That preamble makes both the whole-text JSON.parse above and
+// parsePromptActionFromJsonSequence (which requires no surrounding text) fail, so
+// the action call would otherwise leak into the visible reply. As a tolerant
+// fallback, scan every balanced JSON object in the reply and accept the last one
+// that validates to a KNOWN action. parsePromptActionRecord only accepts objects
+// with a recognised `action` key and required fields, so narrative prose that
+// merely contains braces is never mistaken for an action call.
+function parseEmbeddedPromptActionCall(text: string): ParsedPromptActionCall | undefined {
+  const ranges = jsonObjectRanges(text);
+  for (let index = ranges.length - 1; index >= 0; index -= 1) {
+    const range = ranges[index];
+    try {
+      const action = parsePromptActionRecord(JSON.parse(text.slice(range.start, range.end)) as unknown);
+      if (action) {
+        return action;
+      }
+    } catch {
+      // Not a usable JSON object; try the next range.
+    }
+  }
+  return undefined;
 }
 
 function compactImageAction(value: unknown) {

--- a/src/utils/toon.ts
+++ b/src/utils/toon.ts
@@ -9,7 +9,12 @@ export function stripStructuredResponse(text: string) {
 
 export function parseToonObject(text: string) {
   const stripped = stripStructuredResponse(text);
-  const emptyArrayObject = stripped.match(/^([A-Za-z_][A-Za-z0-9_]*)\[\]\{\}$/);
+  // A declared-empty TOON array header is an empty array — whether the length is
+  // omitted (`name[]{}`) or explicitly zero with declared fields and an optional
+  // header colon (`dialogue[0]{quoteId,speakerId}:`). The underlying decoder
+  // throws on the length-0 header form, so recognise it up front and return the
+  // empty array instead of letting the whole parse fail.
+  const emptyArrayObject = stripped.match(/^([A-Za-z_][A-Za-z0-9_]*)\[0?\]\{[^}]*\}:?\s*$/);
   if (emptyArrayObject) {
     return { [emptyArrayObject[1]]: [] };
   }


### PR DESCRIPTION
## Summary
Two independent robustness fixes for parsing model output. Both are additive
guards — no behavior change on well-formed output, they only recover cases that
previously threw or were silently dropped.

### 1. Tolerate a reasoning/narration preamble before the action JSON

parsePromptActionCall previously required the output to be *pure* JSON — any
prose the model emitted before the action object made the whole call parse as
undefined, so the action was lost. Reasoning-capable models routinely prepend
a sentence or two before the JSON.

Fix: if the strict parse fails, scan the text for balanced-brace JSON object
ranges and try the last valid one as the action record. Well-formed pure-JSON
output takes the original fast path unchanged.

A cleaner long-term fix is native tool-use for the action call; that needs a
larger refactor and is intentionally out of scope here.

### 2. Parse a declared empty-array TOON header as an empty array

The TOON decoder throws on a length-0 array header with declared fields and an
optional trailing colon (e.g. dialogue[0]{quoteId,speakerId}:), which made an
otherwise valid "no items" response fail the whole parse. parseToonObject now
recognises that header form up front and returns the empty array instead.

Test plan

Action JSON preceded by prose → action is parsed (previously dropped).

Pure-JSON action output → unchanged (fast path).

TOON response with a declared empty array header → parses to { name: [] }.