### PR TITLE
fix: preserve emoji when translating with a weak model

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -46,6 +46,7 @@ import {
   type ParsedPhoneMessage,
 } from './chat/phoneMessages';
 import { useNextTurnReferenceImages } from './chat/useNextTurnReferenceImages';
+import { shieldTranslationEmoji, restoreTranslationEmoji } from './chat/translationEmojiShield';
 import { type OutputActionContextCapacityRequest } from './chat/outputActions';
 import {
   applyTimeCommandsToWorkflowNodes,
@@ -3568,8 +3569,12 @@ function App() {
       return '';
     }
     const language = displayLanguageOverride.trim() || 'German';
+    // W11: shield emoji so a weak translation model (e.g. Haiku) cannot mangle
+    // them into U+FFFD replacement characters. Translate ASCII placeholders and
+    // restore the original emoji afterwards (streamed output restored on the fly).
+    const { shielded, tokens } = shieldTranslationEmoji(text);
     const prompt = translationPrompt({
-      text,
+      text: shielded,
       direction,
       displayLanguage: language,
       recentHistoryContext,
@@ -3582,9 +3587,11 @@ function App() {
         nodeId,
         label,
         prompt,
-        onChunk,
+        onChunk: onChunk
+          ? (streamed) => onChunk(restoreTranslationEmoji(streamed, tokens))
+          : undefined,
       });
-      const translated = completion.text.trim();
+      const translated = restoreTranslationEmoji(completion.text, tokens).trim();
       if (!translated) {
         if (direction === 'to-english') {
           return '';

--- a/src/chat/translationEmojiShield.ts
+++ b/src/chat/translationEmojiShield.ts
@@ -1,0 +1,48 @@
+// Shield emoji from a (possibly weak) translation model.
+//
+// Weaker models such as Haiku sometimes emit an invalid/incomplete byte sequence
+// for an emoji; the API then serialises those bytes as U+FFFD replacement
+// characters, so the translated text shows "?"-boxes instead of the emoji. Emoji
+// never need translating, so we replace each emoji grapheme with a plain-ASCII
+// sentinel before translating and restore the original afterwards. A residual
+// U+FFFD strip stays as a safety net for anything that still slips through.
+//
+// Kept ASCII-only on purpose (fromCharCode instead of literal invisible chars)
+// so the source has no zero-width/variation-selector surprises.
+
+const VS16 = String.fromCharCode(0xfe0f); // emoji variation selector-16
+const ZWJ = String.fromCharCode(0x200d); // zero-width joiner (emoji sequences)
+const REPLACEMENT = String.fromCharCode(0xfffd); // U+FFFD replacement character
+
+// Emoji grapheme clusters: a pictographic base, optionally with a skin-tone
+// modifier or VS16, any number of ZWJ-joined pictographs, or a flag (a pair of
+// regional indicators). Matched whole so one placeholder == one emoji.
+const EMOJI_RE = new RegExp(
+  '\\p{Extended_Pictographic}(\\p{Emoji_Modifier}|' + VS16 + ')?' +
+    '(' + ZWJ + '\\p{Extended_Pictographic}(\\p{Emoji_Modifier}|' + VS16 + ')?)*' +
+    '|\\p{Regional_Indicator}{2}',
+  'gu',
+);
+
+// Tolerant of stray whitespace the model might introduce inside the sentinel.
+const SENTINEL_RE = /\[\[\s*E(\d+)\s*\]\]/g;
+
+export function shieldTranslationEmoji(text: string): { shielded: string; tokens: string[] } {
+  const tokens: string[] = [];
+  const shielded = text.replace(EMOJI_RE, (match) => {
+    const index = tokens.length;
+    tokens.push(match);
+    return `[[E${index}]]`;
+  });
+  return { shielded, tokens };
+}
+
+export function restoreTranslationEmoji(text: string, tokens: string[]): string {
+  const restored = text.replace(SENTINEL_RE, (_match, digits: string) => {
+    const index = Number(digits);
+    return index >= 0 && index < tokens.length ? tokens[index] : '';
+  });
+  // Never let a raw replacement character reach the UI/history, even if the model
+  // still garbled something we did not shield.
+  return restored.split(REPLACEMENT).join('');
+}


### PR DESCRIPTION
Weaker models used for display/phone translation (e.g. Haiku) sometimes emit an invalid byte sequence for an emoji; the API then serialises those bytes as U+FFFD replacement characters, so the translated text shows "?"-boxes instead of the emoji (a source "See you soon <emoji>" came back as "... ????").

Shield emoji from the translator: replace each emoji grapheme (incl. ZWJ sequences, flags and skin-tone variants) with a plain-ASCII placeholder before translating, then restore the original emoji into the result (streamed output is restored on the fly). A residual U+FFFD strip stays as a safety net. Emoji are preserved verbatim and never depend on the model reproducing their bytes.