### PR TITLE
fix: robust dialogue quote extraction for mixed quote styles

### DIFF
--- a/src/chat/textRendering.ts
+++ b/src/chat/textRendering.ts
@@ -19,22 +19,45 @@ export const dialogueColors = [
 ];
 
 export function extractDialogueQuotes(text: string): ExtractedQuote[] {
-  const patterns = [
-    /"[^"]*"/g,
-    /„[^„“”]*[“”]/g,
-    /“[^“”]*”/g,
-    /«[^«»]*»/g,
-    /»[^»«]*«/g,
-  ];
-  return patterns
-    .flatMap((pattern) =>
-      Array.from(text.matchAll(pattern), (match) => ({
-        index: match.index,
-        text: match[0],
-      })),
-    )
-    .sort((left, right) => left.index - right.index)
-    .map((quote, index) => ({ ...quote, index }));
+  // Single left-to-right pass. Models and translators frequently MIX quote styles
+  // (e.g. a German opening low-9 quote paired with a straight " close); a per-style
+  // regex then mis-pairs the straight closers and captures the narration BETWEEN
+  // quotes as a "quote". Opening on any opener and closing on the next matching
+  // closer handles mixed and consistent styles alike, in text order (stable ids).
+  const straight = '"';
+  const low = String.fromCharCode(0x201e); // German opening low-9 quote
+  const high = String.fromCharCode(0x201c); // German/curly opening high quote
+  const right = String.fromCharCode(0x201d); // curly closing quote
+  const guillemetOpen = String.fromCharCode(0xab);
+  const guillemetClose = String.fromCharCode(0xbb);
+  const closersByOpener: Record<string, string> = {
+    [straight]: straight + right,
+    [low]: straight + high + right,
+    [high]: straight + right,
+    [guillemetOpen]: guillemetClose,
+    [guillemetClose]: guillemetOpen,
+  };
+  const quotes: ExtractedQuote[] = [];
+  let cursor = 0;
+  while (cursor < text.length) {
+    const closers = closersByOpener[text[cursor]];
+    if (closers) {
+      let end = -1;
+      for (let scan = cursor + 1; scan < text.length; scan += 1) {
+        if (closers.includes(text[scan])) {
+          end = scan;
+          break;
+        }
+      }
+      if (end >= 0) {
+        quotes.push({ index: quotes.length, text: text.slice(cursor, end + 1) });
+        cursor = end + 1;
+        continue;
+      }
+    }
+    cursor += 1;
+  }
+  return quotes;
 }
 
 export function coloredDialogueParts(text: string, dialogue: ChatDialogueQuote[]) {
@@ -82,22 +105,29 @@ export function coloredDialogueParts(text: string, dialogue: ChatDialogueQuote[]
 }
 
 export function quotedSpeechParts(text: string) {
-  const matches = [...text.matchAll(/"[^"\n]+(?:"|$)|„[^“”\n]+(?:[“”]|$)|“[^”\n]+(?:”|$)/g)];
-  if (matches.length === 0) {
+  // Reuse the shared quote tokenizer so mixed quote styles are handled exactly
+  // like speaker highlighting. The previous per-style regex mis-bounded a German
+  // opening closed by a straight quote and spilled trailing narration into the
+  // speech span (also affecting TTS speech/narration segmentation).
+  const quotes = extractDialogueQuotes(text);
+  if (quotes.length === 0) {
     return [{ text }];
   }
 
   const parts: Array<{ text: string; isSpeech?: boolean }> = [];
   let cursor = 0;
-  matches.forEach((match) => {
-    const start = match.index ?? 0;
-    const end = start + match[0].length;
+  for (const quote of quotes) {
+    const start = text.indexOf(quote.text, cursor);
+    if (start < 0) {
+      continue;
+    }
+    const end = start + quote.text.length;
     if (start > cursor) {
       parts.push({ text: text.slice(cursor, start) });
     }
     parts.push({ text: text.slice(start, end), isSpeech: true });
     cursor = end;
-  });
+  }
   if (cursor < text.length) {
     parts.push({ text: text.slice(cursor) });
   }


### PR DESCRIPTION
Speaker highlighting split dialogue with a set of per-style regexes (straight, German, curly, guillemet). Models and translators frequently MIX styles within one line -- e.g. a German opening low-9 quote closed by a straight ASCII quote. The straight-pair regex then pairs the closing quotes of adjacent lines and captures the narration BETWEEN two quotes as a single "quote", while the real dialogue is dropped -- so only a couple of mis-bounded passages reach speaker attribution and highlighting is wrong or missing.

Replace the regexes with one left-to-right tokenizer: open on any opener, close on the next matching closer (a low-9 opener accepts a straight, high or right closer). This handles mixed and consistent styles alike and yields quotes in text order with stable ids. quotedSpeechParts reuses the same tokenizer so the speech/narration split (also used for TTS) stays consistent.