### PR TITLE
fix: scroll the provider dialog when a config is taller than the viewport

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -15524,7 +15524,10 @@ button.message-timeline-row.phone:focus-visible {
   display: grid;
   grid-template-columns: minmax(0, 1fr) 280px;
   gap: 24px;
-  overflow: hidden;
+  /* Scroll when a provider's config is taller than the dialog instead of clipping
+     the bottom; min-height:0 lets this flex child shrink so overflow-y engages. */
+  min-height: 0;
+  overflow-y: auto;
   padding: 0 23px 20px;
 }
 


### PR DESCRIPTION
.connection-dialog-grid used overflow:hidden with no scroll container, so a provider config taller than the dialog (e.g. a voice provider with many fields) had its bottom clipped and was unreachable. Add min-height:0 so this flex child can shrink, and overflow-y:auto so the dialog body scrolls instead of clipping.