### PR TITLE
Fix/character setup dialog scroll

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -15524,7 +15524,10 @@ button.message-timeline-row.phone:focus-visible {
   display: grid;
   grid-template-columns: minmax(0, 1fr) 280px;
   gap: 24px;
-  overflow: hidden;
+  /* Scroll when a provider's config is taller than the dialog instead of clipping
+     the bottom; min-height:0 lets this flex child shrink so overflow-y engages. */
+  min-height: 0;
+  overflow-y: auto;
   padding: 0 23px 20px;
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -12358,6 +12358,11 @@ button.message-timeline-row.phone:focus-visible {
   grid-template-columns: 150px minmax(0, 1fr);
   gap: 16px;
   align-items: start;
+  /* Scroll when a character's setup content is taller than the dialog; min-height:0
+     lets this grid child shrink so overflow-y:auto engages instead of clipping the
+     bottom (mirrors the .connection-dialog-grid dialog scroll fix). */
+  min-height: 0;
+  overflow-y: auto;
 }
 
 .character-setup-tabs {


### PR DESCRIPTION
What

The character setup dialog clipped its content instead of scrolling: when a character's setup content is taller than the dialog (e.g. a long voice provider config with a builder + cloning tab + generation panel), the bottom — including the action buttons — was cut off and unreachable.

Why

.storybook-image-dialog is already bounded to the viewport (max-height: calc(100vh - 56px)) as a flex column, but its .character-setup-layout grid child had no scroll container. Without min-height: 0 a flex/grid child cannot shrink below its content size, so overflow-y: auto never engages and the overflow is clipped.

Fix

Add min-height: 0 + overflow-y: auto to .character-setup-layout so the content scrolls within the bounded dialog. Generic, applies to both setup tabs. Mirrors the existing .connection-dialog-grid dialog scroll fix.

Testing

Opened the character setup dialog with content taller than the viewport; the body now scrolls to the bottom action buttons instead of clipping. No behavior change when the content fits.
