### PR TITLE
perf(providers): pause the local-provider health poll during a run

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1320,6 +1320,7 @@ function App() {
     defaultConnectionId,
     setDefaultConnectionId,
     settingsLoadComplete,
+    isRunning,
     nodesRef,
     setNodes,
     notifySystem,

--- a/src/app/useProviderConnections.ts
+++ b/src/app/useProviderConnections.ts
@@ -129,6 +129,10 @@ type UseProviderConnectionsOptions = {
   defaultConnectionId: string;
   setDefaultConnectionId: (connectionId: string) => void;
   settingsLoadComplete: boolean;
+  // Whether a run/turn is currently active. The background health poll pauses
+  // while true and the connections dialog is closed (providers do not change
+  // mid-run).
+  isRunning: boolean;
   nodesRef: { current: WorkflowNode[] };
   setNodes: Dispatch<SetStateAction<WorkflowNode[]>>;
   notifySystem: (level: 'info' | 'warning' | 'error', text: string) => void;
@@ -140,6 +144,7 @@ export function useProviderConnections({
   defaultConnectionId,
   setDefaultConnectionId,
   settingsLoadComplete,
+  isRunning,
   nodesRef,
   setNodes,
   notifySystem,
@@ -1016,11 +1021,15 @@ export function useProviderConnections({
   const checkProviderConnectionsRef = useRef(checkProviderConnections);
   const inspectComfyWorkflowRef = useRef(inspectComfyWorkflow);
   const editingConnectionRef = useRef(editingConnection);
+  const isRunningRef = useRef(isRunning);
+  const showConnectionsRef = useRef(showConnections);
   useEffect(() => {
     checkProviderConnectionByIdRef.current = checkProviderConnectionById;
     checkProviderConnectionsRef.current = checkProviderConnections;
     inspectComfyWorkflowRef.current = inspectComfyWorkflow;
     editingConnectionRef.current = editingConnection;
+    isRunningRef.current = isRunning;
+    showConnectionsRef.current = showConnections;
   });
 
   useEffect(() => {
@@ -1036,6 +1045,14 @@ export function useProviderConnections({
       return;
     }
     const checkLocalProviders = async () => {
+      // Skip the background health poll while a turn is running AND the
+      // connections dialog is closed — providers do not change mid-run, so this
+      // avoids redundant check-connection round-trips (and the list-models +
+      // settings-save churn they cascade into) during generation. When the dialog
+      // is open the user may be tuning a provider, so keep polling to reflect it.
+      if (isRunningRef.current && !showConnectionsRef.current) {
+        return;
+      }
       if (localProviderPollActiveRef.current) {
         return;
       }


### PR DESCRIPTION
The 2s local-provider health poll (checkLocalProviders) ran regardless of whether a turn was in flight. During generation each cycle re-probed every local provider (check-connection), which refreshed the model list and could rewrite connection state, cascading into extra settings saves — pure churn, since providers do not change mid-run.

Pass the run state into the hook and skip the poll while isRunning is true AND the connections dialog is closed (so a user tuning a provider mid-run still gets live health), read via refs so the interval is not re-created on every toggle.